### PR TITLE
Added text prop for Credit card submit button 

### DIFF
--- a/src/components/CreditCardInput/CreditCardInput.tsx
+++ b/src/components/CreditCardInput/CreditCardInput.tsx
@@ -11,8 +11,10 @@ import { renderWithoutSupportPaymentMethod } from '../../utils';
 import { LoadingCard, PayButton } from './styles';
 
 export interface CreditCardInputProps extends CardOptions {
-  /** Sets text  in Button */
+  /** Sets text  in Button. If children is/are given then not applied */
   text?: string
+  /** Make it possible to put any component inside. If children is/are given then text is not applied */
+  children?: React.ReactNode
   /**
    * Sets the style for the Payment Button using a CSS object
    *
@@ -112,7 +114,7 @@ export const CreditCardInput = ({
         type="button"
         overrideStyles={overrideStyles}
       >
-        {text}
+        {props.children || text}
       </PayButton>
     </>
   );

--- a/src/components/CreditCardInput/CreditCardInput.tsx
+++ b/src/components/CreditCardInput/CreditCardInput.tsx
@@ -11,6 +11,8 @@ import { renderWithoutSupportPaymentMethod } from '../../utils';
 import { LoadingCard, PayButton } from './styles';
 
 export interface CreditCardInputProps extends CardOptions {
+  /** Sets the children in Button */
+  text?: string
   /**
    * Sets the style for the Payment Button using a CSS object
    *
@@ -49,6 +51,7 @@ export interface CreditCardInputProps extends CardOptions {
 export const CreditCardInput = ({
   overrideStyles,
   focus = 'cardNumber',
+  text = 'Pay',
   ...props
 }: CreditCardInputProps): JSX.Element | null => {
   const [card, setCard] = React.useState<Card | undefined>(() => undefined);
@@ -109,7 +112,7 @@ export const CreditCardInput = ({
         type="button"
         overrideStyles={overrideStyles}
       >
-        Pay
+        {text}
       </PayButton>
     </>
   );

--- a/src/components/CreditCardInput/CreditCardInput.tsx
+++ b/src/components/CreditCardInput/CreditCardInput.tsx
@@ -11,7 +11,7 @@ import { renderWithoutSupportPaymentMethod } from '../../utils';
 import { LoadingCard, PayButton } from './styles';
 
 export interface CreditCardInputProps extends CardOptions {
-  /** Sets the children in Button */
+  /** Sets text  in Button */
   text?: string
   /**
    * Sets the style for the Payment Button using a CSS object


### PR DESCRIPTION
Hi, I'm trying to integrate square payment on my project and for design needs I need to style submit button and change text in it. It is possible now to do it with help of pseudo-elements but it is defiantly not a good way to do this :).
Currently in my code I have something like this to set necessary text and styling for button.

```JS
{
    background: '#483b85',
    color: 'transparent', // to hide "Pay" text of original button
    transition: '.1s linear',
    content: `""`,
    position: 'relative',
    ":hover": {
      background: '#6b3f8c'
    },
    "::after": {
      marginLeft: '-28px', // "Pay" text is hardcoded in button as default
      content: `"Pay $${amount}"`,
      fontSize: '1rem',
      fontWeight: 800,
      color: '#ffffff',
      backgroundColor: 'transparent',
      lineHeight: '20px',
    },
    "::before": {
      content: `url(${lock})`, // SVG
      marginRight: '10px'
    }
  }
```