### PR TITLE
Fix form loading state after submission

### DIFF
--- a/src/components/ach/ach.tsx
+++ b/src/components/ach/ach.tsx
@@ -66,7 +66,8 @@ export function Ach({
       });
 
       if (result.status === 'OK') {
-        return cardTokenizeResponseReceived(result);
+        const tokenizedResult = await cardTokenizeResponseReceived(result);
+        return tokenizedResult;
       }
 
       let message = `Tokenization failed with status: ${result.status}`;

--- a/src/components/credit-card/credit-card.tsx
+++ b/src/components/credit-card/credit-card.tsx
@@ -93,7 +93,8 @@ function CreditCard({
       const result = await card.tokenize();
 
       if (result.status === 'OK') {
-        return cardTokenizeResponseReceived(result);
+        const tokenizedResult = await cardTokenizeResponseReceived(result);
+        return tokenizedResult
       }
 
       let message = `Tokenization failed with status: ${result.status}`;

--- a/src/components/gift-card/gift-card.tsx
+++ b/src/components/gift-card/gift-card.tsx
@@ -85,7 +85,8 @@ function GiftCard({
       const result = await giftCard?.tokenize();
 
       if (result.status === 'OK') {
-        return cardTokenizeResponseReceived(result);
+        const tokenizedResult = await cardTokenizeResponseReceived(result);
+        return tokenizedResult;
       }
 
       let message = `Tokenization failed with status: ${result.status}`;

--- a/src/contexts/form/form.tsx
+++ b/src/contexts/form/form.tsx
@@ -13,7 +13,7 @@ import type { FormContextType, FormProviderProps } from './form.types';
  * expose access to the Web Payment SDK library.
  */
 const FormContext = React.createContext<FormContextType>({
-  cardTokenizeResponseReceived: null as unknown as () => void,
+  cardTokenizeResponseReceived: null as unknown as () => Promise<void>,
   createPaymentRequest: null as unknown as Square.PaymentRequestOptions,
   payments: null as unknown as Square.Payments,
 });
@@ -55,13 +55,13 @@ function FormProvider({ applicationId, locationId, children, overrides, ...props
 
   const cardTokenizeResponseReceived = async (rest: Square.TokenResult): Promise<void> => {
     if (rest.errors || !props.createVerificationDetails) {
-      props.cardTokenizeResponseReceived(rest);
+      await props.cardTokenizeResponseReceived(rest);
       return;
     }
 
     const verifyBuyerResults = await instance?.verifyBuyer(String(rest.token), props.createVerificationDetails());
 
-    props.cardTokenizeResponseReceived(rest, verifyBuyerResults);
+    await props.cardTokenizeResponseReceived(rest, verifyBuyerResults);
   };
 
   // Fixes stale closure issue with using React Hooks & SqPaymentForm callback functions

--- a/src/contexts/form/form.types.ts
+++ b/src/contexts/form/form.types.ts
@@ -11,7 +11,7 @@ export type FormContextType = {
   cardTokenizeResponseReceived: (
     token: Square.TokenResult,
     verifiedBuyer?: Square.VerifyBuyerResponseDetails | null
-  ) => void;
+  ) => Promise<void>;
   /**
    * Returned by `Square.payments(appId, locationId)`.
    *
@@ -45,7 +45,7 @@ export type FormProviderProps = {
   cardTokenizeResponseReceived: (
     token: Square.TokenResult,
     verifiedBuyer?: Square.VerifyBuyerResponseDetails | null
-  ) => void;
+  ) => void | Promise<void>;
   children: React.ReactNode;
   /**
    * Identifies the location of the merchant that is taking the payment.


### PR DESCRIPTION
### Your checklist for this pull request

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start _your branch_ off _our main_.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.

### Description

Fixes a bug which means the form loading state doesn't wait for the verification token to be completed before setting loading to `false` again. This means you can click the pay button multiple times and be charged twice.

This change now waits for the tokenize response, including waiting for the `verifyBuyer` to be called (if required). Previously it will just instantly return an incomplete promise and set loading to `false`.

I've also added another await for the `props.cardTokenizeResponseReceived` meaning that optionally we can make the function async and process an api request to make the payment. Without this the form button gets enabled again while waiting for the api request to complete.

Updated the types to match and tested with my own application and working as expected. No breaking changes, just a new type which allows `cardTokenizeResponseReceived` to be async if needed.

I've only updated the forms which have a loading state as the others (apple and google) wouldn't matter if we awaited or not as there are no state updates.