### PR TITLE
fix: cashApp not destroyed on unmount

### DIFF
--- a/src/components/cash-app-pay/cash-app-pay.tsx
+++ b/src/components/cash-app-pay/cash-app-pay.tsx
@@ -53,6 +53,7 @@ function CashAppPay({
 
     const abortController = new AbortController();
     const { signal } = abortController;
+    let cashApp: Square.CashAppPay | undefined;
 
     const start = async (signal: AbortSignal) => {
       const paymentRequest = payments?.paymentRequest(createPaymentRequest);
@@ -62,7 +63,7 @@ function CashAppPay({
       }
 
       try {
-        const cashApp = await payments?.cashAppPay(paymentRequest, paymentRequestOptions).then((res) => {
+        cashApp = await payments?.cashAppPay(paymentRequest, paymentRequestOptions).then((res) => {
           if (signal?.aborted) {
             return;
           }
@@ -73,10 +74,6 @@ function CashAppPay({
         });
 
         await cashApp?.attach(`#${id}`, options);
-
-        if (signal.aborted) {
-          await cashApp?.destroy();
-        }
       } catch (error) {
         console.error('Initializing Cash App Pay failed', error);
       }
@@ -86,6 +83,7 @@ function CashAppPay({
 
     return () => {
       abortController.abort();
+      cashApp?.destroy();
     };
   }, [createPaymentRequest, options, paymentRequestOptions, payments]);
 


### PR DESCRIPTION
### Your checklist for this pull request

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start _your branch_ off _our main_.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description

On our checkout page, we have a back button that will unmount the `CashAppPay` component. When we try to pay again, we get this error:
```
Initializing Cash App Pay failed CashAppPayError: already rendered. must destroy before rendering again
```
This PR is calling `cashApp?.destroy();` on `useEffect` cleanup function so that it's properly destroyed on unmount and works as expected when re-mounting.